### PR TITLE
🔧 HOTFIX: Fix Docker Buildx cache error on main branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -72,23 +72,17 @@ jobs:
       
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      
-    - name: Cache Docker layers
-      uses: actions/cache@v4
       with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ matrix.service }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ matrix.service }}-
-          
-    - name: Build Docker image
+        driver: docker-container
+        
+    - name: Build Docker image (with GitHub Actions cache)
       uses: docker/build-push-action@v5
       with:
         context: .
         file: services/${{ matrix.service }}/Dockerfile
         tags: test-${{ matrix.service }}:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         load: true
         
     - name: Test Docker image
@@ -101,11 +95,6 @@ jobs:
         sleep 2
         docker logs test-server-${{ matrix.service }} | grep -q "listening on" && echo "✅ Server starts correctly"
         docker stop test-server-${{ matrix.service }} || true
-        
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Switch to docker-container driver for cache support
- Use GitHub Actions cache (type=gha) instead of local cache
- Remove manual cache management steps
- Fixes CI/CD Pipeline failure: 'Cache export is not supported for the docker driver'

This fixes the build failure after merge to main branch.